### PR TITLE
fix: the one probe遮挡问题, 删除万用皮肤补丁中不需要的皮肤源

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /versions/
 /mods/
 /crash-reports/
-/CustomSkinLoader/
+# /CustomSkinLoader/
 /shaderpacks/
 /ambience_music/
 /backups/

--- a/CustomSkinLoader/CustomSkinLoader.json
+++ b/CustomSkinLoader/CustomSkinLoader.json
@@ -1,0 +1,30 @@
+{
+  "version": "14.13",
+  "buildNumber": 303,
+  "loadlist": [
+    {
+      "name": "Mojang",
+      "type": "MojangAPI",
+      "apiRoot": "https://api.mojang.com/",
+      "sessionRoot": "https://sessionserver.mojang.com/"
+    },
+    {
+      "name": "LittleSkin",
+      "type": "CustomSkinAPI",
+      "root": "https://littlesk.in/csl/"
+    }
+  ],
+  "enableDynamicSkull": true,
+  "enableTransparentSkin": true,
+  "forceIgnoreHttpsCertificate": false,
+  "forceLoadAllTextures": false,
+  "enableCape": true,
+  "forceFillSkullNBT": false,
+  "threadPoolSize": 3,
+  "retryTime": 1,
+  "cacheExpiry": 30,
+  "forceUpdateSkull": false,
+  "enableLocalProfileCache": false,
+  "enableCacheAutoClean": false,
+  "forceDisableCache": false
+}

--- a/config/theoneprobe-client.toml
+++ b/config/theoneprobe-client.toml
@@ -54,7 +54,7 @@ boxLeftX = 5
 boxRightX = -1
 #The distance to the top side of the screen. Use -1 if you don't want to set this
 #Range: -1 ~ 10000
-boxTopY = 5
+boxTopY = 16
 #The distance to the bottom side of the screen. Use -1 if you don't want to set this
 #Range: -1 ~ 10000
 boxBottomY = -1


### PR DESCRIPTION
`TOP检测器`窗口会遮挡天气预报栏, 下移了一点

`万用皮肤补丁`删去了除Mojang和LittleSkin以外的所有皮肤源 (毕竟除了这俩应该也没人用) , 能提升皮肤加载速度. 尤其是有插件基于物品栏和头颅的UI, 源太多半天加载不出来